### PR TITLE
fix: include bootstrap manifests

### DIFF
--- a/work/manifests/flux.yaml
+++ b/work/manifests/flux.yaml
@@ -1,0 +1,23 @@
+# Flux configuration for reconciling the Supernetes controller
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: supernetes
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://github.com/supernetes/deploy
+  ref:
+    branch: master
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: supernetes
+  namespace: flux-system
+spec:
+  interval: 1m
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: supernetes

--- a/work/manifests/kustomization.yaml
+++ b/work/manifests/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - flux.yaml


### PR DESCRIPTION
These were referenced by `supernetes-cluster.yaml`, but accidentally excluded from the initial commit.