### PR TITLE
fix: update .gitignore for bootstrap manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,7 @@
 !/work/**/
 !/work/cpouta
 !/work/supernetes-cluster.yaml
+!/work/manifests/flux.yaml
+!/work/manifests/kustomization.yaml
 !/work/patch/cilium.yaml
 !/work/patch/single-node.yaml


### PR DESCRIPTION
One more fix for https://github.com/supernetes/bootstrap/pull/2...