### PR TITLE
docs: add notice about cert SAN if using DDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Start by logging into cPouta and selecting the right project from the top left. 
 
 Then, click on your username from the top right and select `OpenStack RC File`. This will give you a file named `project_1234567-openrc.sh` which will be used by the scripts for API access. Save it into the `work` directory, which is used as the working directory of the container.
 
-Next, since cPouta only hands out ephemeral IPv4 addresses, we need to set up [Dynamic DNS (DDNS)](https://en.wikipedia.org/wiki/Dynamic_DNS) for the cluster. This can be done using external services, such as [dy.fi](https://www.dy.fi/) (Finland-only), or any other service supported by [ddclient](https://ddclient.net/). A configuration template is provided in [`ddclient.template.conf`](work/ddclient.template.conf). Copying this file to `ddclient.conf` and filling it out will set up automatic dynamic DNS reconciliation in the cluster during bringup.
+Next, since cPouta only hands out ephemeral IPv4 addresses, we need to set up [Dynamic DNS (DDNS)](https://en.wikipedia.org/wiki/Dynamic_DNS) for the cluster. This can be done using external services, such as [dy.fi](https://www.dy.fi/) (Finland-only), or any other service supported by [ddclient](https://ddclient.net/). A configuration template is provided in [`ddclient.template.conf`](work/ddclient.template.conf). Copying this file to `ddclient.conf` and filling it out will set up automatic dynamic DNS reconciliation in the cluster during bring-up.
 
 Finally, inside the [container](#usage), run
 
@@ -42,6 +42,14 @@ talosctl gen secrets # Generate Talos secrets (one-time)
 ```
 
 The nodes should now be running with the baseline configuration, and ready to be fully configured with `talos-bootstrap`.
+
+> [!IMPORTANT]
+> If using dynamic DNS, the cPouta tooling will automatically register the DDNS FQDN as a SAN for the cluster certificate. To preserve access after running `talos-bootstrap`, it must be fed a configuration patch that looks as follows:
+> ```yaml
+> machine:
+>   certSANs:
+>     - cluster.example.com # Add DNS FQDN as SAN to cluster cert
+>  ```
 
 ### Applying Supernetes Configuration with `talos-bootstrap`
 


### PR DESCRIPTION
Adding the DDNS FQDN to the cluster cert SAN list must be done to preserve access.