### PR TITLE
fix: add Helm labels and annotations to `cilium` GatewayClass

### DIFF
--- a/work/manifests/gateway-api/manifests/gateway-class.yaml
+++ b/work/manifests/gateway-api/manifests/gateway-class.yaml
@@ -1,6 +1,15 @@
+# The `cilium` GatewayClass should technically be deployed automatically,
+# however, that is not reliable in practice. We can specify the resource here,
+# but the Helm labels and annotations must also be present, otherwise Cilium
+# won't deploy without complaining.
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: cilium
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: cilium
+    meta.helm.sh/release-namespace: kube-system
 spec:
   controllerName: io.cilium/gateway-controller


### PR DESCRIPTION
This fixes the deployment flakiness of and Helm's complaints about the `cilium` GatewayClass.