### PR TITLE
feat: add `supernetes-workload` namespace for untracked workloads

### DIFF
--- a/work/manifests/supernetes/kustomization.yaml
+++ b/work/manifests/supernetes/kustomization.yaml
@@ -1,5 +1,3 @@
-namespace: supernetes
-
 resources:
   - manifests/gateway.yaml
   - manifests/namespace.yaml

--- a/work/manifests/supernetes/manifests/gateway.yaml
+++ b/work/manifests/supernetes/manifests/gateway.yaml
@@ -2,6 +2,7 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: supernetes
+  namespace: supernetes
 spec:
   gatewayClassName: cilium
   listeners:

--- a/work/manifests/supernetes/manifests/namespace.yaml
+++ b/work/manifests/supernetes/manifests/namespace.yaml
@@ -2,3 +2,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: supernetes
+---
+# Namespace for untracked Supernetes workloads
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: supernetes-workload


### PR DESCRIPTION
This namespace is currently hard-coded in Supernetes, and needs to be externally deployed.