### PR TITLE
feat: switch from `standard.large` to `standard.xlarge` in cPouta

### DIFF
--- a/work/cpouta
+++ b/work/cpouta
@@ -137,7 +137,7 @@ set -o pipefail
 	talosctl config merge talosconfig
 
 	# Create VMs
-	openstack server create --flavor standard.large --nic port-id="$_machine" --image talos --user-data controlplane.yaml "$_machine"
+	openstack server create --flavor standard.xlarge --nic port-id="$_machine" --image talos --user-data controlplane.yaml "$_machine"
 
 	# Wait for the cluster to become healthy
 	while ! talosctl health; do sleep 1; done


### PR DESCRIPTION
The latter has 16 GiB of RAM compared to the former's 8 GiB, which is needed for scaling to 1000+ VK instances in the controller.