### PR TITLE
feat: parallelize utility container builds when using Podman

### DIFF
--- a/container
+++ b/container
@@ -10,9 +10,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 _build() {
-        # If _FULL_RECREATE is set, append --no-cache
-        "$RUNTIME" build -t supernetes-bootstrap ${_FULL_RECREATE+--no-cache} .
-        unset _FULL_RECREATE # Don't keep re-downloading in case this loops
+    # If _FULL_RECREATE is set, append --no-cache
+    # If using Podman, the build process needs to be explicitly parallelized
+    case "$RUNTIME" in */podman) _IS_PODMAN=1;; esac
+    "$RUNTIME" build ${_IS_PODMAN+--jobs "$(nproc)"} -t supernetes-bootstrap ${_FULL_RECREATE+--no-cache} .
+    unset _FULL_RECREATE # Don't keep re-downloading in case this loops
 }
 
 unset _RECREATE


### PR DESCRIPTION
`podman build` requires the [`--jobs` flag](https://docs.podman.io/en/latest/markdown/podman-build.1.html#jobs-number) to perform parallel builds in contrast to Docker (BuildKit) which does it by default.