### PR TITLE
fix: switch from linuxserver/ddclient to plain ddclient for reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !/work/**/
 !/work/cpouta
 !/work/ddclient.template.conf
+!/work/ddclient.yaml
 !/work/supernetes-cluster.yaml
 !/work/manifests/cert-approver/**
 !/work/manifests/flux/**

--- a/work/cpouta
+++ b/work/cpouta
@@ -145,39 +145,11 @@ set -o pipefail
 	sed -i "s/$_private_ip/$_public_ip/g" ~/.kube/config
 
 	if [ -n "$_fqdn" ]; then
-		# Deploy linuxserver/ddclient to perform periodic Dynamic DNS (DDNS) updates
+		# Deploy ddclient to perform periodic Dynamic DNS (DDNS) updates
 		kubectl create namespace ddns
-		kubectl -n ddns create secret generic ddns-config \
+		kubectl -n ddns create secret generic ddclient-config \
 			--from-file=ddclient.conf=ddclient.conf
-		kubectl apply -f <(cat <<- EOF
-			apiVersion: apps/v1
-			kind: Deployment
-			metadata:
-			  name: ddns
-			  namespace: ddns
-			spec:
-			  selector:
-			    matchLabels:
-			      app: ddns
-			  template:
-			    metadata:
-			      labels:
-			        app: ddns
-			    spec:
-			      containers:
-			        - name: ddclient
-			          image: linuxserver/ddclient:3.11.2
-			          securityContext:
-			            privileged: false
-			          volumeMounts:
-			            - mountPath: /defaults
-			              name: ddns-config
-			      volumes:
-			        - name: ddns-config
-			          secret:
-			            secretName: ddns-config
-			EOF
-		)
+		kubectl apply -f ddclient.yaml
 
 		# Use the FQDN instead of the public IP
 		talosctl --talosconfig talosconfig config endpoint "$_fqdn"

--- a/work/ddclient.yaml
+++ b/work/ddclient.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ddns
+  namespace: ddns
+spec:
+  selector:
+    matchLabels:
+      app: ddns
+  template:
+    metadata:
+      labels:
+        app: ddns
+    spec:
+      containers:
+        - name: ddclient
+          image: alpine:3
+          command:
+            - /bin/sh
+            - -xec
+            - |
+              apk --no-cache add ddclient
+              exec ddclient -foreground -file /config/ddclient.conf
+          securityContext:
+            privileged: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /config
+              name: ddclient-config
+      volumes:
+        - name: ddclient-config
+          secret:
+            secretName: ddclient-config
+            defaultMode: 0400


### PR DESCRIPTION
The [linuxserver/ddclient](https://docs.linuxserver.io/images/docker-ddclient/) image is somehow [very unreliable](https://github.com/linuxserver/docker-ddclient/issues/87) and may get stuck after some time, causing loss of access to the cluster though the DDNS record. Attempt to mitigate this situation by using the vanilla Alpine Linux version.