### PR TITLE
fix: disable forwarding `kube-dns` to host DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 !/work/manifests/supernetes/**
 !/work/manifests/kustomization.yaml
 !/work/patch/cilium.yaml
+!/work/patch/dns.yaml
 !/work/patch/metrics-server.yaml
 !/work/patch/single-node.yaml

--- a/work/patch/dns.yaml
+++ b/work/patch/dns.yaml
@@ -1,0 +1,8 @@
+# Talos' way of redirecting kube-dns (CoreDNS) to the host doesn't work with Cilium if
+# bpf.hostLegacyRouting=false and/or bpf.masquerade=true. For more information, see
+# https://github.com/siderolabs/talos/pull/9200.
+machine:
+  features:
+    hostDNS:
+      enabled: true
+      forwardKubeDNSToHost: false

--- a/work/supernetes-cluster.yaml
+++ b/work/supernetes-cluster.yaml
@@ -15,6 +15,7 @@ cluster:
     all-namespaces: false # Set to "false" to make Flux only watch the installation namespace (optional)
   patches: # Any cluster-wide patches to apply when creating the configuration with `talosctl gen config` (optional)
     - "@patch/cilium.yaml"
+    - "@patch/dns.yaml"
     - "@patch/metrics-server.yaml"
     - "@patch/single-node.yaml"
   manifests: manifests # Kustomization directory for additional manifests to be applied into the cluster (optional)


### PR DESCRIPTION
This [feature](https://www.talos.dev/v1.9/talos-guides/network/host-dns/#forwarding-kube-dns-to-host-dns) is newly enabled by default, but doesn't work right with Cilium at the moment, see comments at https://github.com/siderolabs/talos/pull/9200. Thus, disable it here for now.