### PR TITLE
fix: dynamic DNS updates

### DIFF
--- a/work/ddclient.template.conf
+++ b/work/ddclient.template.conf
@@ -5,7 +5,7 @@
 
 daemon=60
 usev4=webv4
-webv4=he
+webv4=he.net
 server=www.dy.fi
 protocol=dyndns2
 login=<email>

--- a/work/ddclient.yaml
+++ b/work/ddclient.yaml
@@ -35,9 +35,6 @@ spec:
           securityContext:
             privileged: false
             allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
           volumeMounts:
             - mountPath: /config
               name: ddclient-config


### PR DESCRIPTION
`ddclient` installation now results in `Operation not permitted` with capabilities dropped, so let's go with the defaults, which do work.